### PR TITLE
Update torch to avoid is_sm80, is_sm90 error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
-torch==2.1.1
-torchvision==0.16.1
+torch==2.2.1
+torchvision==0.17.1
 lightning==2.1.2
 transformers==4.35.2
 diffusers==0.24.0
-torch_pruning==1.3.2
+accelerate==0.25.0
 datasets==2.17.0
+torch_pruning==1.3.2
 bitsandbytes==0.42.0
 tqdm
 argparse
@@ -15,6 +16,5 @@ ftfy
 regex
 wandb
 pynvml
-accelerate
 clip @ git+https://github.com/openai/CLIP.git
 scikit-image


### PR DESCRIPTION
Sometimes running `text_to_image/train_text_to_image_lora.py` on certain machines throw the same error as in https://github.com/huggingface/diffusers/issues/6160. Updating `torch` to 2.2.1 resolves this issue. With this, `torchvision` also needs to be updated to 0.17.1.

In this PR, I also version `accelerate`. I've always run my experiments with `accelerate==0.25.0`.